### PR TITLE
fix: use Nunjucks default filter instead of nullish coalescing

### DIFF
--- a/content/catalog-info.yaml
+++ b/content/catalog-info.yaml
@@ -4,5 +4,5 @@ metadata:
   name: ${{ values.name | dump }}
 spec:
   type: service
-  owner: ${{ values.owner ?? 'guest' }}
+  owner: ${{ values.owner | default('group:default/guests') | dump }}
   lifecycle: experimental


### PR DESCRIPTION
## Summary
Fixes the template rendering error that occurs when creating a new Node.js service.

## Problem
The template was using the `??` (nullish coalescing) operator which is not supported in Backstage's Nunjucks templating engine, causing:
```
Error: (unknown path) [Line 7, Column 27] expected variable end
```

## Solution
- Changed from `${{ values.owner ?? 'guest' }}` to `${{ values.owner | default('group:default/guests') | dump }}`
- Uses Nunjucks' built-in `default` filter
- Added `dump` filter for proper escaping

## Testing
- Tested with Backstage 1.41.1
- Template now renders correctly with and without owner parameter

Fixes #2